### PR TITLE
auth none means no auth at all

### DIFF
--- a/3proxy.cfg
+++ b/3proxy.cfg
@@ -5,7 +5,7 @@ nserver *.*.*.*
 nserver *.*.*.*
 nscache 65536
 log /dev/null
-auth none
+auth iponly
 timeouts 1 5 30 60 180 1800 15 60
 allow * * 149.154.160.0/20 443 CONNECT * *
 allow * * 91.108.4.0/22 443 CONNECT * *


### PR DESCRIPTION
set it to iponly to enable target subnets rules
https://3proxy.ru/howtor.asp#AUTH